### PR TITLE
Update development tools for live reloading

### DIFF
--- a/06-building-container-images/api-golang/Dockerfile.8
+++ b/06-building-container-images/api-golang/Dockerfile.8
@@ -15,13 +15,13 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 FROM build-base AS dev
 
-# Install air for hot reload & delve for debugging
-RUN go install github.com/cosmtrek/air@latest && \
-  go install github.com/go-delve/delve/cmd/dlv@latest
+# Install CompileDaemon for hot reload
+RUN go install github.com/githubnemo/CompileDaemon@latest
 
 COPY . .
 
-CMD ["air", "-c", ".air.toml"]
+# Use CompileDaemon for live reloading
+CMD ["CompileDaemon", "--build=go build -o api-golang", "--command=./api-golang"]
 
 FROM build-base AS build-production
 

--- a/08-running-containers/client-react/vite.config.js
+++ b/08-running-containers/client-react/vite.config.js
@@ -22,5 +22,9 @@ export default defineConfig({
         secure: false,
       },
     },
+    watch: {
+      usePolling: true, // Add this to enable polling for file changes
+      interval: 10,  // Adjust the polling interval if needed
+    },
   },
 });


### PR DESCRIPTION
- Replaced `air` with `CompileDaemon` for Go hot reload due to issues with `air` and compatibility concerns.
- Updated Dockerfile to install `CompileDaemon` and configure it for live reloading.
- Changed Vite configuration to use polling for file changes to improve live reload reliability.