### PR TITLE
Fix docker build of golang-api dev image

### DIFF
--- a/06-building-container-images/api-golang/Dockerfile.8
+++ b/06-building-container-images/api-golang/Dockerfile.8
@@ -1,7 +1,7 @@
 # Pin specific version for stability
 # Use separate stage for building image
 # Use debian for easier build utilities
-FROM golang:1.19-bullseye AS build-base
+FROM golang:1.23-bullseye AS build-base
 
 WORKDIR /app 
 
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM build-base AS dev
 
 # Install air for hot reload & delve for debugging
-RUN go install github.com/cosmtrek/air@latest && \
+RUN go install github.com/air-verse/air@latest && \
   go install github.com/go-delve/delve/cmd/dlv@latest
 
 COPY . .


### PR DESCRIPTION
Docker build of golang-api development image fails with the following error:

<img width="565" alt="image" src="https://github.com/user-attachments/assets/821973e2-a80a-4329-aa8e-48eaf4523397" />

It is because the installation process of `air` tool [has been changed](https://github.com/air-verse/air?tab=readme-ov-file#via-go-install-recommended). This PR contains changes to fix `air` tool installation.

