### PR TITLE
fix: fixes Air and Delve installation for compatibility with Go 1.23

### DIFF
--- a/06-building-container-images/api-golang/Dockerfile.8
+++ b/06-building-container-images/api-golang/Dockerfile.8
@@ -1,7 +1,7 @@
 # Pin specific version for stability
 # Use separate stage for building image
 # Use debian for easier build utilities
-FROM golang:1.19-bullseye AS build-base
+FROM golang:1.23-bullseye AS build-base
 
 WORKDIR /app 
 
@@ -16,8 +16,8 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM build-base AS dev
 
 # Install air for hot reload & delve for debugging
-RUN go install github.com/cosmtrek/air@latest && \
-  go install github.com/go-delve/delve/cmd/dlv@latest
+RUN go install github.com/air-verse/air@v1.61.7 && \
+  go install github.com/go-delve/delve/cmd/dlv@v1.21.0
 
 COPY . .
 


### PR DESCRIPTION
This pull request updates the development environment to support Go 1.23 by using specific versions of Air (v1.61.7) and Delve (v1.21.0) in the Dockerfile. The previous configuration caused build failures due to module path conflicts and version incompatibilities. By pinning the versions explicitly, we ensure compatibility with Go 1.23 and avoid potential issues with future updates to these tools.