### PR TITLE
fix pgdata volume mount command to expose port 5432

### DIFF
--- a/04-using-3rd-party-containers/README.md
+++ b/04-using-3rd-party-containers/README.md
@@ -198,7 +198,7 @@ cat /var/lib/docker/volumes/my-volume/_data/hello.txt # Woohoo! we found our dat
 This approach can then be used to mount a volume at the known path where a program persists its data:
 ```bash
 # Create a container from the postgres container image and mount its known storage path into a volume named pgdata
-docker run -it --rm -v pgdata:/var/lib/postgresql/data -e POSTGRES_PASSWORD=foobarbaz postgres:15.1-alpine
+docker run -it --rm -p 5432:5432 -v pgdata:/var/lib/postgresql/data -e POSTGRES_PASSWORD=foobarbaz postgres:15.1-alpine
 ```
 
 #### ii. Bind Mounts


### PR DESCRIPTION
I think there is a problem with a command in course 4. Under Section B.ii., there is a command to mount a volume to postgres. However, the command does not expose port number 5432. As a result, the database cannot be connected from the host machine. Here is the command:

```
# Create a container from the postgres container image and mount its known storage path into a volume named pgdata
docker run -it --rm -v pgdata:/var/lib/postgresql/data -e POSTGRES_PASSWORD=foobarbaz postgres:15.1-alpine
```

I added '-p 5432:5432' and it works:
`docker run -it --rm -p 5432:5432 -v pgdata:/var/lib/postgresql/data -e POSTGRES_PASSWORD=foobarbaz postgres:15.1-alpine`